### PR TITLE
Add application/x-mpegURL mime type for m3u8 enclosures

### DIFF
--- a/src/lib/Editor/Tags/EpisodeMetadata/components/Enclosure.svelte
+++ b/src/lib/Editor/Tags/EpisodeMetadata/components/Enclosure.svelte
@@ -32,6 +32,7 @@
 		: episodes.findIndex((v) => v === $editingEpisode?.enclosure?.['@_url']);
 
 	const mimeTypes = [
+		{ extension: 'm3u8', type: 'application/x-mpegURL' },
 		{ extension: 'aac', type: 'audio/aac' },
 		{ extension: 'mp3', type: 'audio/mpeg' },
 		{ extension: 'oga', type: 'audio/ogg' },


### PR DESCRIPTION
This adds the proper mime type for m3u8 enclosures so that podcast players know to treat them as HLS. SF currently defaults these to audio/mpeg, which causes players to treat them as audio-only.