### PR TITLE
Handle Alby accounts with no customKey/customValue

### DIFF
--- a/src/lib/Editor/Tags/Value/SharedValueComponent.svelte
+++ b/src/lib/Editor/Tags/Value/SharedValueComponent.svelte
@@ -95,8 +95,8 @@
 				updateRecipientData(
 					info.pubkey,
 					name + '@getalby.com',
-					info.customData[0].customValue,
-					info.customData[0].customKey
+					info.customData[0]?.customValue,
+					info.customData[0]?.customKey
 				);
 				cancelProviderSubmit();
 			} else {

--- a/src/lib/Editor/Tags/ValueSplits/ValueSplits.svelte
+++ b/src/lib/Editor/Tags/ValueSplits/ValueSplits.svelte
@@ -164,8 +164,8 @@
 				updateRecipientData(
 					info.pubkey,
 					name + '@getalby.com',
-					info.customData[0].customValue,
-					info.customData[0].customKey
+					info.customData[0]?.customValue,
+					info.customData[0]?.customKey
 				);
 				cancelProviderSubmit();
 			} else {


### PR DESCRIPTION
Alby accounts attached to Alby Hub nodes have their own pubkeys and no longer use custom keys/values. (see: https://getalby.com/.well-known/keysend/ericpp ). This causes an error with SF as it seems to expect that customKey/customValue are returned from the Alby keysend well-known.

This PR uses the question mark operator to handle the case where customKey/customValue are not returned by the Alby keysend well-known.